### PR TITLE
Align ik_ref and fk_ref with the wrist when needed.

### DIFF
--- a/scripts/mgear/shifter_classic_components/arm_2jnt_04/__init__.py
+++ b/scripts/mgear/shifter_classic_components/arm_2jnt_04/__init__.py
@@ -279,6 +279,10 @@ class Component(component.Main):
                                                     self.normal,
                                                     "xz",
                                                     self.negate)
+
+        if self.settings["guideOrientWrist"]:
+            trnIK_ref = wt
+
         self.ik_ref = primitive.addTransform(self.ik_ctl_ref,
                                              self.getName("ik_ref"),
                                              trnIK_ref)


### PR DESCRIPTION
This is related to a bug reported on the forums; http://forum.mgear-framework.com/t/arm-2jnt-04-and-ik-fk-switch-in-synoptic/697